### PR TITLE
添加 2021 级编译原理课程设计项目

### DIFF
--- a/projects/Advanced-Labs-in-Compilers.md
+++ b/projects/Advanced-Labs-in-Compilers.md
@@ -18,3 +18,4 @@
 - [PostGuard](https://github.com/post-guard/Canon) (C#, Pascal-S 到 C 的编译器)
 - [RowletQwQ & JollyCorivuG & Mono312 & zjsycwmrbig & zhiruozzy](https://github.com/RowletQwQ/BUPT-PASCC) (C++, Pascal-S 到 C/RISC-V 的编译器)
 - [Nerlci & 3DRX & weiguang1 & daixinwang & 11BugMaker](https://github.com/Nerlci/passcal) (ANTLR4 & C++ & LLVM, Pascal-S 编译器)
+- [scallion7](https://github.com/scallion7/BUPT_Bachelor/tree/main/三年级junior/编译原理课设/最终提交) (Python & PLY & PyQt5, Pascal-S 到 C 的编译器)


### PR DESCRIPTION
- 课程：编译原理课程设计
- 年级：2021级
- 项目地址：https://github.com/scallion7/BUPT_Bachelor/tree/main/三年级junior/编译原理课设/最终提交
- 技术栈：Python、PLY、PyQt5
- 项目简介：Pascal-S 到 C 的编译器
- 已确认课程结束并出分：是