### PR TITLE
修复 scallion7 编译原理课设项目链接

### DIFF
--- a/projects/Advanced-Labs-in-Compilers.md
+++ b/projects/Advanced-Labs-in-Compilers.md
@@ -18,4 +18,4 @@
 - [PostGuard](https://github.com/post-guard/Canon) (C#, Pascal-S 到 C 的编译器)
 - [RowletQwQ & JollyCorivuG & Mono312 & zjsycwmrbig & zhiruozzy](https://github.com/RowletQwQ/BUPT-PASCC) (C++, Pascal-S 到 C/RISC-V 的编译器)
 - [Nerlci & 3DRX & weiguang1 & daixinwang & 11BugMaker](https://github.com/Nerlci/passcal) (ANTLR4 & C++ & LLVM, Pascal-S 编译器)
-- [scallion7](https://github.com/scallion7/BUPT_Bachelor/tree/main/三年级junior/编译原理课设/最终提交) (Python & PLY & PyQt5, Pascal-S 到 C 的编译器)
+- [scallion7](https://github.com/scallion7/BUPT_Bachelor/tree/main/三年级junior/大三下/编译原理课设/最终提交) (Python & PLY & PyQt5, Pascal-S 到 C 的编译器)


### PR DESCRIPTION
## 修改内容

- 修正 `projects/Advanced-Labs-in-Compilers.md` 中 scallion7 编译原理课程设计项目的链接。
- 在目标路径中补充缺失的 `大三下` 目录。

## 修改原因

原链接在 PR #131 创建时指向：

`三年级junior/编译原理课设/最终提交`

之后 `BUPT_Bachelor` 仓库通过提交 `ae24b72` 按学期重组了大三课程目录，项目被移动到：

`三年级junior/大三下/编译原理课设/最终提交`

因此原链接现在返回 404。本次修改将索引更新为项目的当前有效地址。

## 影响

- 恢复 scallion7 项目条目的正常访问。
- 不修改项目描述或其他课程条目。

## 验证

- 已通过 GitHub API 确认新路径存在并能列出项目文件。
- `git diff --check` 通过。
